### PR TITLE
Fix/fetch commits calendar

### DIFF
--- a/web/src/pages/calendar.tsx
+++ b/web/src/pages/calendar.tsx
@@ -18,25 +18,26 @@ const CalendarPage = () => {
   const [selectedDate, setSelectedDate] = useState('')
   const [commitDetails, setCommitDetails] = useState<Commit[]>([])
   const [open, setOpen] = useState(false)
+  const [dateRange, setDateRange] = useState({ start: '', end: '' })
 
   const { repos, selectedRepo, setSelectedRepo, setRepos } = useAppContext()
   console.log('repos', repos)
   const { org: orgName, name: repoName } = selectedRepo || {}
 
   useEffect(() => {
-    if (!selectedRepo) return
+    if (!selectedRepo || !dateRange.start || !dateRange.end) return
 
     const fetchCommits = async () => {
       const apiUrl = process.env.NEXT_PUBLIC_API_URL
-      let url = `${apiUrl}/api/commits?repoName=${repoName}&orgName=${orgName}`
-      console.log('fetching sync status', url)
+      let url = `${apiUrl}/api/commits?repoName=${repoName}&orgName=${orgName}&startDate=${dateRange.start}&endDate=${dateRange.end}&allPages=true`
+      // console.log('fetching sync status', url)
 
       if (selectedDate) {
         url += `&date=${selectedDate}`
       }
       try {
         const response = await fetch(url)
-        console.log('response:', response)
+        // console.log('response:', response)
         if (!response.ok) {
           const errorText = await response.text()
           throw new Error(
@@ -59,7 +60,7 @@ const CalendarPage = () => {
       }
     }
     fetchCommits()
-  }, [repoName, orgName, selectedRepo, selectedDate])
+  }, [repoName, orgName, selectedRepo, selectedDate, dateRange])
 
   const handleRepoSelect = (repoId: string) => {
     const repo = repos.find((r) => r.id === repoId)
@@ -89,6 +90,13 @@ const CalendarPage = () => {
     }
   }
 
+  const handleDatesSet = (info: any) => {
+    setDateRange({
+      start: info.startStr,
+      end: info.endStr,
+    })
+  }
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">My Commits Calendar</h1>
@@ -115,6 +123,7 @@ const CalendarPage = () => {
           }}
           eventClassNames={() => ' text-xs truncate'}
           dateClick={handleDateClick}
+          datesSet={handleDatesSet}
         />
       </div>
       <ModalCommits


### PR DESCRIPTION
| Before                       | After                        |
|------------------------------|------------------------------|
| No date filtering for commit fetches.      | Commits now filtered by selected date range.        |
| *Commits were fetched without the ability to specify a date range.* | *Commits can now be fetched by specifying `startDate` and `endDate`, improving the calendar functionality.* |

<!-- Link References -->
[before-image]: https://github.com/link-to-before-screenshot
[after-image]: https://github.com/link-to-after-screenshot

##  Changes

- Added `startDate` and `endDate` parameters to the `fetchCommitsForUserInRepo` function in `commits.ts`.
- Updated the calendar component (`calendar.tsx`) to handle selected date ranges and pass them to the API for filtering commits.
- Refactored API request URLs to include the selected date range (`startDate`, `endDate`) when fetching commits.
- Introduced the `datesSet` handler in the Calendar page to manage date range selection.
- Enhanced commit fetching to allow for paginated requests when `allPages=true` is passed.
- Improved error handling for API requests.

##  How to Test

1. Navigate to the Calendar page in the application.
2. Select a repository and specify a date range using the calendar.
3. Ensure that commits displayed are filtered according to the selected dates.
4. Test with different repositories and date ranges to verify the correct behavior.
5. Verify that pagination works when `allPages=true`, fetching all commits within the selected range.
6. Ensure no commits are fetched when no commits exist in the selected range.
